### PR TITLE
Added 'final' to fillsJsonNullForEmbulkNull field

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -124,5 +124,5 @@ public class JacksonAllInObjectScope
 
     private final TimestampFormatter timestampFormatter;
     private final StringJsonParser jsonParser;
-    private boolean fillsJsonNullForEmbulkNull;
+    private final boolean fillsJsonNullForEmbulkNull;
 }


### PR DESCRIPTION
Hi @kfitzgerald, I wanted to minor change your https://github.com/embulk/embulk-base-restclient/pull/102. This PR adds `final` modifier to `fillsJsonNullForEmbulkNull` field because it could be immutable. What do you think?